### PR TITLE
Fix the JWT format, it generated tokens with wrong permissions

### DIFF
--- a/stream-core/src/main/java/io/getstream/client/util/JwtAuthenticationUtil.java
+++ b/stream-core/src/main/java/io/getstream/client/util/JwtAuthenticationUtil.java
@@ -25,7 +25,7 @@ public class JwtAuthenticationUtil {
      * @param userId UserId (if null it will not be added to the payload)
      * @return Token string
      */
-    public static String generateToken(final String secretKey, final String action, final String resource, final String feedId, final String userId) {
+    public static String generateToken(final String secretKey, final String resource, final String action, final String feedId, final String userId) {
         Map<String, Object> claims = new LinkedHashMap<String, Object>();
         claims.put("action", action);
         claims.put("resource", resource);

--- a/stream-core/src/test/java/io/getstream/client/util/JwtAuthenticationUtilTest.java
+++ b/stream-core/src/test/java/io/getstream/client/util/JwtAuthenticationUtilTest.java
@@ -25,12 +25,13 @@ public class JwtAuthenticationUtilTest {
                 JwtAuthenticationUtil.generateToken(
                         SECRET_KEY,
                         "activities",
-                        "myResource",
+                        "read",
                         null,
                         null)
         );
         assertTrue(map.size() > 0);
-        assertThat(map.get("action").toString(), is("activities"));
+        assertThat(map.get("action").toString(), is("read"));
+        assertThat(map.get("resource").toString(), is("activities"));
     }
 
     @Test
@@ -44,7 +45,7 @@ public class JwtAuthenticationUtilTest {
                         null)
         );
         assertTrue(map.size() > 0);
-        assertThat(map.get("resource").toString(), is(ALL));
+        assertThat(map.get("action").toString(), is(ALL));
         assertThat(map.get("feed_id").toString(), is("feedId"));
     }
 
@@ -59,7 +60,7 @@ public class JwtAuthenticationUtilTest {
                         "userId1")
         );
         assertTrue(map.size() > 0);
-        assertThat(map.get("resource").toString(), is(ALL));
+        assertThat(map.get("action").toString(), is(ALL));
         assertThat(map.get("user_id").toString(), is("userId1"));
     }
 
@@ -74,7 +75,7 @@ public class JwtAuthenticationUtilTest {
                         "userId1")
         );
         assertTrue(map.size() > 0);
-        assertThat(map.get("resource").toString(), is(ALL));
+        assertThat(map.get("action").toString(), is(ALL));
         assertThat(map.get("feed_id").toString(), is("feedId"));
         assertThat(map.get("user_id").toString(), is("userId1"));
     }


### PR DESCRIPTION
Tokens with permissions like:
```js
{
    'action': u'activities', 
    'feed_id': u'*', 
    'resource': u'*'
}
```

instead of ones like this:
```js
{
    'action': '*', 
    'feed_id': '*', 
    'resource': 'activities'
}
```