### PR TITLE
Bump retrolambda for gradle 5.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "me.tatarka.retrolambda" version "3.7.0"
+    id "me.tatarka.retrolambda" version "3.7.1"
     id 'java-library'
     id 'eclipse'
     id 'idea'


### PR DESCRIPTION
gradle switched using a different folder for each language to support multi languages.

src: related issue touching us
https://github.com/evant/gradle-retrolambda/issues/273