### PR TITLE
Add empty string validation to paginated reactions request for enhancement

### DIFF
--- a/src/main/java/io/getstream/core/StreamReactions.java
+++ b/src/main/java/io/getstream/core/StreamReactions.java
@@ -144,6 +144,7 @@ public final class StreamReactions {
   public CompletableFuture<Paginated<Reaction>> paginatedFilter(Token token, String next)
       throws StreamException {
     checkNotNull(next, "next can't be null");
+    checkArgument(!next.trim().isEmpty(), "next can't be empty");
 
     try {
       final URL url = new URL(baseURL, next);


### PR DESCRIPTION
Found out `next` param in returned JSON is deserialized to empty string object.
Then when an empty string is passed into the method, it threw a confusing exception.
So I added this validation to let users know that invalid param.