### PR TITLE
Add optional paramater "withOwnChildren" to filter call

### DIFF
--- a/src/main/java/io/getstream/cloud/CloudReactionsClient.java
+++ b/src/main/java/io/getstream/cloud/CloudReactionsClient.java
@@ -1,8 +1,5 @@
 package io.getstream.cloud;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.collect.Iterables;
 import io.getstream.core.LookupKind;
 import io.getstream.core.StreamReactions;
@@ -13,8 +10,12 @@ import io.getstream.core.models.Reaction;
 import io.getstream.core.options.Filter;
 import io.getstream.core.options.Limit;
 import io.getstream.core.utils.DefaultOptions;
-import java.util.List;
 import java8.util.concurrent.CompletableFuture;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public final class CloudReactionsClient {
   private final Token token;
@@ -31,70 +32,80 @@ public final class CloudReactionsClient {
     return reactions.get(token, id);
   }
 
-  public CompletableFuture<List<Reaction>> filter(LookupKind lookup, String id)
-      throws StreamException {
-    return filter(lookup, id, DefaultOptions.DEFAULT_FILTER, DefaultOptions.DEFAULT_LIMIT, "");
+  public CompletableFuture<List<Reaction>> filter(LookupKind lookup, String id) throws StreamException {
+    Params params = new Params(lookup, id);
+    return filter(params);
   }
 
-  public CompletableFuture<List<Reaction>> filter(LookupKind lookup, String id, Limit limit)
-      throws StreamException {
-    return filter(lookup, id, DefaultOptions.DEFAULT_FILTER, limit, "");
+  public CompletableFuture<List<Reaction>> filter(LookupKind lookup, String id, Limit limit) throws StreamException {
+    Params params = new Params(lookup, id).withLimit(limit);
+    return filter(params);
   }
 
-  public CompletableFuture<List<Reaction>> filter(LookupKind lookup, String id, Filter filter)
-      throws StreamException {
-    return filter(lookup, id, filter, DefaultOptions.DEFAULT_LIMIT, "");
+  public CompletableFuture<List<Reaction>> filter(LookupKind lookup, String id, Filter filter) throws StreamException {
+    Params params = new Params(lookup, id).withFilter(filter);
+    return filter(params);
   }
 
-  public CompletableFuture<List<Reaction>> filter(LookupKind lookup, String id, String kind)
-      throws StreamException {
-    return filter(lookup, id, DefaultOptions.DEFAULT_FILTER, DefaultOptions.DEFAULT_LIMIT, kind);
+  public CompletableFuture<List<Reaction>> filter(LookupKind lookup, String id, String kind) throws StreamException {
+    Params params = new Params(lookup, id).withKind(kind);
+    return filter(params);
   }
 
-  public CompletableFuture<List<Reaction>> filter(
-      LookupKind lookup, String id, Filter filter, Limit limit) throws StreamException {
-    return filter(lookup, id, filter, limit, "");
+  public CompletableFuture<List<Reaction>> filter(LookupKind lookup, String id, Filter filter, Limit limit) throws StreamException {
+    Params params = new Params(lookup, id).withFilter(filter).withLimit(limit);
+    return filter(params);
   }
 
-  public CompletableFuture<List<Reaction>> filter(
-      LookupKind lookup, String id, Limit limit, String kind) throws StreamException {
-    return filter(lookup, id, DefaultOptions.DEFAULT_FILTER, limit, kind);
+  public CompletableFuture<List<Reaction>> filter(LookupKind lookup, String id, Limit limit, String kind) throws StreamException {
+    Params params = new Params(lookup, id).withLimit(limit).withKind(kind);
+    return filter(params);
   }
 
-  public CompletableFuture<List<Reaction>> filter(
-      LookupKind lookup, String id, Filter filter, Limit limit, String kind)
-      throws StreamException {
-    return reactions.filter(token, lookup, id, filter, limit, kind);
+  public CompletableFuture<List<Reaction>> filter(LookupKind lookup, String id, Filter filter, Limit limit, String kind)
+          throws StreamException {
+    Params params = new Params(lookup, id).withLimit(limit).withKind(kind).withFilter(filter).withLimit(limit);
+    return filter(params);
+  }
+
+  public CompletableFuture<List<Reaction>> filter(LookupKind lookup, String id, Filter filter, Limit limit, String kind, Boolean includeOwnChildren)
+          throws StreamException {
+    Params params = new Params(lookup, id).withLimit(limit).withKind(kind).withFilter(filter).withLimit(limit).includeOwnChildren(includeOwnChildren);
+    return filter(params);
+  }
+
+  private CompletableFuture<List<Reaction>> filter(Params params) throws StreamException {
+    return reactions.filter(token, params.getLookupKind(), params.getId(), params.getFilter(), params.getLimit(), params.getKind(), params.getWithOwnChildren());
   }
 
   public CompletableFuture<Reaction> add(
-      String kind, String activityID, Iterable<FeedID> targetFeeds) throws StreamException {
+          String kind, String activityID, Iterable<FeedID> targetFeeds) throws StreamException {
     return add(userID, kind, activityID, targetFeeds);
   }
 
   public CompletableFuture<Reaction> add(String kind, String activityID, FeedID... targetFeeds)
-      throws StreamException {
+          throws StreamException {
     return add(userID, activityID, targetFeeds);
   }
 
   public CompletableFuture<Reaction> add(Reaction reaction, Iterable<FeedID> targetFeeds)
-      throws StreamException {
+          throws StreamException {
     return add(userID, reaction, targetFeeds);
   }
 
   public CompletableFuture<Reaction> add(Reaction reaction, FeedID... targetFeeds)
-      throws StreamException {
+          throws StreamException {
     return add(userID, reaction, targetFeeds);
   }
 
   public CompletableFuture<Reaction> add(
-      String userID, String kind, String activityID, Iterable<FeedID> targetFeeds)
-      throws StreamException {
+          String userID, String kind, String activityID, Iterable<FeedID> targetFeeds)
+          throws StreamException {
     return add(userID, kind, activityID, Iterables.toArray(targetFeeds, FeedID.class));
   }
 
   public CompletableFuture<Reaction> add(
-      String userID, String kind, String activityID, FeedID... targetFeeds) throws StreamException {
+          String userID, String kind, String activityID, FeedID... targetFeeds) throws StreamException {
     checkNotNull(kind, "Reaction kind can't be null");
     checkArgument(!kind.isEmpty(), "Reaction kind can't be empty");
     checkNotNull(activityID, "Reaction activity id can't be null");
@@ -104,44 +115,44 @@ public final class CloudReactionsClient {
   }
 
   public CompletableFuture<Reaction> add(
-      String userID, Reaction reaction, Iterable<FeedID> targetFeeds) throws StreamException {
+          String userID, Reaction reaction, Iterable<FeedID> targetFeeds) throws StreamException {
     return add(userID, reaction, Iterables.toArray(targetFeeds, FeedID.class));
   }
 
   public CompletableFuture<Reaction> add(String userID, Reaction reaction, FeedID... targetFeeds)
-      throws StreamException {
+          throws StreamException {
     return reactions.add(token, userID, reaction, targetFeeds);
   }
 
   public CompletableFuture<Reaction> addChild(
-      String userID, String kind, String parentID, Iterable<FeedID> targetFeeds)
-      throws StreamException {
+          String userID, String kind, String parentID, Iterable<FeedID> targetFeeds)
+          throws StreamException {
     Reaction child = Reaction.builder().kind(kind).parent(parentID).build();
     return add(userID, child, targetFeeds);
   }
 
   public CompletableFuture<Reaction> addChild(
-      String userID, String kind, String parentID, FeedID... targetFeeds) throws StreamException {
+          String userID, String kind, String parentID, FeedID... targetFeeds) throws StreamException {
     Reaction child = Reaction.builder().kind(kind).parent(parentID).build();
     return add(userID, child, targetFeeds);
   }
 
   public CompletableFuture<Reaction> addChild(
-      String userID, String parentID, Reaction reaction, Iterable<FeedID> targetFeeds)
-      throws StreamException {
+          String userID, String parentID, Reaction reaction, Iterable<FeedID> targetFeeds)
+          throws StreamException {
     Reaction child = Reaction.builder().fromReaction(reaction).parent(parentID).build();
     return add(userID, child, targetFeeds);
   }
 
   public CompletableFuture<Reaction> addChild(
-      String userID, String parentID, Reaction reaction, FeedID... targetFeeds)
-      throws StreamException {
+          String userID, String parentID, Reaction reaction, FeedID... targetFeeds)
+          throws StreamException {
     Reaction child = Reaction.builder().fromReaction(reaction).parent(parentID).build();
     return add(userID, child, targetFeeds);
   }
 
   public CompletableFuture<Void> update(String id, Iterable<FeedID> targetFeeds)
-      throws StreamException {
+          throws StreamException {
     return update(id, Iterables.toArray(targetFeeds, FeedID.class));
   }
 
@@ -153,16 +164,82 @@ public final class CloudReactionsClient {
   }
 
   public CompletableFuture<Void> update(Reaction reaction, Iterable<FeedID> targetFeeds)
-      throws StreamException {
+          throws StreamException {
     return update(reaction, Iterables.toArray(targetFeeds, FeedID.class));
   }
 
   public CompletableFuture<Void> update(Reaction reaction, FeedID... targetFeeds)
-      throws StreamException {
+          throws StreamException {
     return reactions.update(token, reaction, targetFeeds);
   }
 
   public CompletableFuture<Void> delete(String id) throws StreamException {
     return reactions.delete(token, id);
   }
+
+  public class Params {
+   private LookupKind lookupKind;
+   private String id;
+   private Filter filter;
+   private Limit limit;
+   private String kind;
+   private Boolean withOwnChildren;
+   public Params(LookupKind lookupKind, String id) {
+     this.id = id;
+     this.lookupKind = lookupKind;
+   }
+
+   public Params withLimit(Limit limit){
+     this.limit = limit;
+     return this;
+  }
+
+  public Params withFilter(Filter filter) {
+     this.filter = filter;
+     return this;
+  }
+
+    public Params withKind(String kind) {
+      this.kind = kind;
+      return this;
+    }
+
+    public Params includeOwnChildren(Boolean includeOwnChildren) {
+      this.withOwnChildren = includeOwnChildren;
+      return this;
+    }
+
+    public LookupKind getLookupKind() {
+      return lookupKind;
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public Filter getFilter() {
+      return (filter != null) ? filter : DefaultOptions.DEFAULT_FILTER;
+    }
+
+    public Limit getLimit() {
+      return (limit != null) ? limit : DefaultOptions.DEFAULT_LIMIT;
+    }
+
+    public String getKind() {
+      return (kind != null) ? kind : "";
+    }
+
+    public Boolean getWithOwnChildren() {
+      return (withOwnChildren != null) ? withOwnChildren : false;
+    }
+  }
 }
+
+
+
+
+
+
+
+
+

--- a/src/main/java/io/getstream/core/StreamReactions.java
+++ b/src/main/java/io/getstream/core/StreamReactions.java
@@ -1,12 +1,5 @@
 package io.getstream.core;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static io.getstream.core.utils.Request.*;
-import static io.getstream.core.utils.Routes.buildReactionsURL;
-import static io.getstream.core.utils.Serialization.*;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableMap;
@@ -20,15 +13,23 @@ import io.getstream.core.options.CustomQueryParameter;
 import io.getstream.core.options.Filter;
 import io.getstream.core.options.Limit;
 import io.getstream.core.options.RequestOption;
+import java8.util.J8Arrays;
+import java8.util.concurrent.CompletableFuture;
+import java8.util.concurrent.CompletionException;
+
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
-import java8.util.J8Arrays;
-import java8.util.concurrent.CompletableFuture;
-import java8.util.concurrent.CompletionException;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.getstream.core.utils.Request.*;
+import static io.getstream.core.utils.Routes.buildReactionsURL;
+import static io.getstream.core.utils.Serialization.*;
 
 public final class StreamReactions {
   private final String key;
@@ -84,7 +85,13 @@ public final class StreamReactions {
   }
 
   public CompletableFuture<List<Reaction>> filter(
-      Token token, LookupKind lookup, String id, Filter filter, Limit limit, String kind)
+          Token token, LookupKind lookup, String id, Filter filter, Limit limit, String kind)
+          throws StreamException {
+    return filter(token, lookup, id, filter, limit, kind, null);
+  }
+
+  public CompletableFuture<List<Reaction>> filter(
+      Token token, LookupKind lookup, String id, Filter filter, Limit limit, String kind, Boolean withOwnChildren)
       throws StreamException {
     checkNotNull(lookup, "Lookup kind can't be null");
     checkNotNull(id, "Reaction ID can't be null");
@@ -97,8 +104,11 @@ public final class StreamReactions {
       RequestOption withActivityData =
           new CustomQueryParameter(
               "with_activity_data", Boolean.toString(lookup == LookupKind.ACTIVITY_WITH_DATA));
+      RequestOption ownChildren =
+              new CustomQueryParameter(
+                      "withOwnChildren", Boolean.toString(withOwnChildren != null && withOwnChildren));
       return httpClient
-          .execute(buildGet(url, key, token, filter, limit, withActivityData))
+          .execute(buildGet(url, key, token, filter, limit, withActivityData, ownChildren))
           .thenApply(
               response -> {
                 try {
@@ -113,7 +123,13 @@ public final class StreamReactions {
   }
 
   public CompletableFuture<Paginated<Reaction>> paginatedFilter(
-      Token token, LookupKind lookup, String id, Filter filter, Limit limit, String kind)
+          Token token, LookupKind lookup, String id, Filter filter, Limit limit, String kind)
+          throws StreamException {
+    return paginatedFilter(token, lookup, id, filter, limit, kind, null);
+  }
+
+  public CompletableFuture<Paginated<Reaction>> paginatedFilter(
+      Token token, LookupKind lookup, String id, Filter filter, Limit limit, String kind, Boolean withOwnChildren)
       throws StreamException {
     checkNotNull(lookup, "Lookup kind can't be null");
     checkNotNull(id, "Reaction ID can't be null");
@@ -126,8 +142,12 @@ public final class StreamReactions {
       RequestOption withActivityData =
           new CustomQueryParameter(
               "with_activity_data", Boolean.toString(lookup == LookupKind.ACTIVITY_WITH_DATA));
+      RequestOption ownChildren =
+              new CustomQueryParameter(
+                      "withOwnChildren", Boolean.toString(withOwnChildren != null && withOwnChildren));
+
       return httpClient
-          .execute(buildGet(url, key, token, filter, limit, withActivityData))
+          .execute(buildGet(url, key, token, filter, limit, withActivityData, ownChildren))
           .thenApply(
               response -> {
                 try {


### PR DESCRIPTION
That's useful when using stream-java in android (fixes the issue https://github.com/GetStream/stream-java/issues/96#issue-927361683) 
On Swift (iOS) the parameter is set by default in every call, I chose to make it optional to maintain the current behaviour.
