### PR TITLE
Compile with java17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Commit message lint
         uses: wagoid/commitlint-github-action@v4

--- a/.github/workflows/initiate_release.yml
+++ b/.github/workflows/initiate_release.yml
@@ -12,9 +12,13 @@ jobs:
     name: 🚀 Create release PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # gives the changelog generator access to all previous commits
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Update CHANGELOG.md, build.gradle and push release branch
         env:

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -8,9 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
+        - uses: actions/setup-java@v3
+          with:
+            distribution: 'temurin'
+            java-version: '17'
       - name: Set up Node.js 16
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       - uses: actions/github-script@v5
         with:
           script: |

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,8 @@ repositories {
     maven { url uri('https://repo.maven.apache.org/maven2/') }
 }
 
+var jackson_version = '2.14.2'
+
 dependencies {
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
@@ -24,13 +26,13 @@ dependencies {
     testImplementation 'com.pholser:junit-quickcheck-generators:0.8.1'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.2.0'
 
-    implementation 'com.google.guava:guava:20.0'
-    implementation 'com.squareup.okhttp3:okhttp:3.11.0'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.9.10'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.9.10'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.9.10'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.10'
-    implementation 'com.auth0:java-jwt:3.4.0'
+    implementation 'com.google.guava:guava:31.1-jre'
+    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+    implementation "com.fasterxml.jackson.core:jackson-core:$jackson_version"
+    implementation "com.fasterxml.jackson.core:jackson-core:$jackson_version"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
+    implementation 'com.auth0:java-jwt:4.2.2'
 
     api 'net.sourceforge.streamsupport:streamsupport:1.7.0'
     api 'net.sourceforge.streamsupport:streamsupport-cfuture:1.7.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id "me.tatarka.retrolambda" version "3.7.1"
     id 'java-library'
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
     id 'com.diffplug.spotless' version '5.14.0'
@@ -35,10 +34,6 @@ dependencies {
 
     api 'net.sourceforge.streamsupport:streamsupport:1.7.0'
     api 'net.sourceforge.streamsupport:streamsupport-cfuture:1.7.0'
-}
-
-retrolambda {
-    javaVersion JavaVersion.VERSION_1_7
 }
 
 def localProperties = new Properties()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Allowing the project to be compiled with JDK 17. 

Setting CI to use Java 17. 

Removing `retrolambda` to fix build with the new JDK. Retrolambda is no longer necessary to the repository because we set the bytecode to be compatible with java 8, not java 6 or 7. 