### PR TITLE
Fix maven version usage in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add the following dependency to your `pom.xml`:
 <dependency>
     <groupId>io.getstream.client</groupId>
     <artifactId>stream-java</artifactId>
-    <version>$stream_version</version>
+    <version>${stream_version}</version>
 </dependency>
 ```
 


### PR DESCRIPTION
References to a version in maven was missing brackets.